### PR TITLE
Putting arity first allows a sort by arity experience.

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -695,7 +695,7 @@ defmodule IEx.Autocomplete do
   ## Ad-hoc conversions
 
   defp to_entries(%{kind: :function, name: name, arity: arity}) do
-    ["#{name}/#{arity}"]
+    ["#{arity}/#{name}"]
   end
 
   defp to_entries(%{kind: :sigil, name: name}) do


### PR DESCRIPTION
This was a fun challenge, but I do not think it will get into elixir because it increases the api surface which they try to keep small. But hey! It works: 
<img width="1146" alt="it works" src="https://github.com/MichaelDimmitt/elixir/assets/11463275/6c71693c-5004-4a1c-a54f-a62569c2e800">

None of the sorting done in IEx.Autocomplete actually matters because erlang sorts by text after IEx is done making changes. This change works to show arity by default because it puts the numbers to the left and those are put first in a text based sort.

Remaining TODO:
1. update / add tests, 
2. add keyword to trigger this type of sort

For instance the letter a could be an iex helper.
`a Elixir.Version.`
or `Elixir.Version. a`
or pass a flag when you start iex --arity-first
or setup a config in .iex file to allow you to do this https://hexdocs.pm/iex/IEx.html#module-configuring-the-shell
